### PR TITLE
Remove Vue 3 beta depenency now that 3 is released

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "vue-template-compiler": "^2.5.22"
   },
   "dependencies": {
-    "vue": "^3.0.0-beta.20"
+    "vue": "^3.0.0"
   }
 }


### PR DESCRIPTION
Now that Vue 3 has general release, the beta dependency is no longer required. PR now only requires v3.0.0